### PR TITLE
fix vim stdin reading

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -13,4 +13,4 @@ fi
 
 ln -sf $path/vimrc ~/.vimrc
 
-vim +PlugUpgrade +PlugInstall +PlugUpdate +PlugClean +qall
+vim - +PlugUpgrade +PlugInstall +PlugUpdate +PlugClean +qall


### PR DESCRIPTION
Resolve

```
Vim: Warning: Input is not from a terminal
```

In order for you to read properly from stdin you need to tell VIM explicitly to do that by using the - parameter at the commandline.